### PR TITLE
fix(apollo): make apollo client a dependency

### DIFF
--- a/addon/apollo.js
+++ b/addon/apollo.js
@@ -1,43 +1,25 @@
-import { assert } from "@ember/debug";
-import {
-  dependencySatisfies,
-  macroCondition,
-  importSync,
-} from "@embroider/macros";
+import { setContext } from "@apollo/client/link/context";
+import { onError } from "@apollo/client/link/error";
 import { handleUnauthorized } from "ember-simple-auth-oidc";
 
-let apolloMiddleware;
+export default function apolloMiddleware(httpLink, session) {
+  const authMiddleware = setContext(async (_, context) => {
+    await session.refreshAuthentication.perform();
 
-if (macroCondition(dependencySatisfies("@apollo/client", ">=3.0.0"))) {
-  const { setContext } = importSync("@apollo/client/link/context");
-  const { onError } = importSync("@apollo/client/link/error");
+    return {
+      ...context,
+      headers: {
+        ...context.headers,
+        ...session.headers,
+      },
+    };
+  });
 
-  apolloMiddleware = (httpLink, session) => {
-    const authMiddleware = setContext(async (_, context) => {
-      await session.refreshAuthentication.perform();
+  const authAfterware = onError((error) => {
+    if (error.networkError && error.networkError.statusCode === 401) {
+      handleUnauthorized(session);
+    }
+  });
 
-      return {
-        ...context,
-        headers: {
-          ...context.headers,
-          ...session.headers,
-        },
-      };
-    });
-
-    const authAfterware = onError((error) => {
-      if (error.networkError && error.networkError.statusCode === 401) {
-        handleUnauthorized(session);
-      }
-    });
-
-    return authMiddleware.concat(authAfterware).concat(httpLink);
-  };
-} else {
-  apolloMiddleware = () =>
-    assert(
-      "@apollo/client >= 3.0.0 must be installed in order to use the apollo middleware"
-    );
+  return authMiddleware.concat(authAfterware).concat(httpLink);
 }
-
-export default apolloMiddleware;

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test:ember-compatibility": "ember try:each"
   },
   "dependencies": {
+    "@apollo/client": "^3.7.0",
     "@embroider/macros": "^1.9.0",
     "base64-js": "^1.5.1",
     "ember-auto-import": "^2.4.3",
@@ -40,7 +41,6 @@
   "devDependencies": {
     "@adfinis-sygroup/eslint-config": "1.5.0",
     "@adfinis-sygroup/semantic-release-config": "3.4.0",
-    "@apollo/client": "3.7.0",
     "@ember/optional-features": "2.0.0",
     "@ember/test-helpers": "2.8.1",
     "@embroider/test-setup": "1.8.3",
@@ -79,14 +79,6 @@
     "qunit": "2.19.2",
     "qunit-dom": "2.0.0",
     "webpack": "5.74.0"
-  },
-  "peerDependencies": {
-    "@apollo/client": ">= 3.0.0"
-  },
-  "peerDependenciesMeta": {
-    "@apollo/client": {
-      "optional": true
-    }
   },
   "engines": {
     "node": "14.* || >= 16"


### PR DESCRIPTION
This is necessary since embroider doesn't handle optional dependencies properly as reported here: https://github.com/embroider-build/embroider/issues/1266

This commit makes `@apollo/client` temporarly a non optional dependency to fix the current issue we have in apps without that dependency. However, we need to revert this as soon as the issue above is resolved since we don't want to enforce this dependency.

Related to #597