### PR TITLE
fix: always reconnect on unauthorized responses

### DIFF
--- a/addon/services/session.js
+++ b/addon/services/session.js
@@ -52,10 +52,14 @@ export default class Service extends SessionServiceESA {
     const isExpired = expireTime && expireTime <= new Date().getTime();
 
     if (this.isAuthenticated && isExpired) {
-      return yield this.session.authenticate("authenticator:oidc", {
-        redirectUri: this.redirectUri,
-        isRefresh: true,
-      });
+      try {
+        return yield this.session.authenticate("authenticator:oidc", {
+          redirectUri: this.redirectUri,
+          isRefresh: true,
+        });
+      } catch (e) {
+        console.warn("Token is invalid. Re-authentification is required.");
+      }
     }
   }
 

--- a/addon/unauthorized.js
+++ b/addon/unauthorized.js
@@ -5,16 +5,13 @@ import { getConfig } from "ember-simple-auth-oidc/config";
 import getAbsoluteUrl from "ember-simple-auth-oidc/utils/absolute-url";
 
 export default function handleUnauthorized(session) {
-  if (session.isAuthenticated) {
-    session.set("data.nextURL", location.href.replace(location.origin, ""));
-    session.invalidate();
-
-    if (macroCondition(isTesting())) {
-      // don't redirect in tests
-    } else {
-      location.replace(
-        getAbsoluteUrl(getConfig(getOwner(session)).afterLogoutUri || "")
-      );
-    }
+  session.set("data.nextURL", location.href.replace(location.origin, ""));
+  session.invalidate();
+  if (macroCondition(isTesting())) {
+    // don't redirect in tests
+  } else {
+    location.replace(
+      getAbsoluteUrl(getConfig(getOwner(session)).afterLogoutUri || "")
+    );
   }
 }


### PR DESCRIPTION
Normally, you should handle `invalidateSession` events directly via the [`handleInvalidation`](https://github.com/mainmatter/ember-simple-auth/blob/ffa070ab6eb8a8907d2c549aedc0c6edd73a3300/packages/ember-simple-auth/addon/services/session.js#L369) method. [Some circumstance in the past](https://github.com/adfinis/ember-simple-auth-oidc/commit/628eecb77a518122b5c877cccf4fed2bcf279530#diff-e322dfc58f6dc338aaf40c1cdf9c5c55d702cf37b4ca713482ceb64f3ad2b3f0R38) motivated us to move it to `handleUnauthorized` and mute the default behavior of `handleInvalidation`. Meanwhile a lot of [things changed](https://github.com/mainmatter/ember-simple-auth/releases) and `ember-simple-auth` received some refactorings. Sadly the `handleInvalidation` hook is still not working out for us, since the session get's invalidated by the token refresh mechanism.

As we have the problem, that sessions which are expired can still send requests to the backend and then receive a `401` response and still won't redirect to the auth page, we have to re-consider how we handle unauthorized requests.

This PR proposes two changes:
* redirect to auth page when token refresh fails, assuming the refresh token expired
* catch any edge cases in the `handleUnauthorized` method
