### PR TITLE
fix: prevent redirect loops to login route

### DIFF
--- a/addon/unauthorized.js
+++ b/addon/unauthorized.js
@@ -1,17 +1,27 @@
 import { getOwner } from "@ember/application";
+import { next } from "@ember/runloop";
 import { isTesting, macroCondition } from "@embroider/macros";
 
 import { getConfig } from "ember-simple-auth-oidc/config";
 import getAbsoluteUrl from "ember-simple-auth-oidc/utils/absolute-url";
 
 export default function handleUnauthorized(session) {
-  session.set("data.nextURL", location.href.replace(location.origin, ""));
-  session.invalidate();
+  if (session.isAuthenticated) {
+    // Only store current location for redirect if the session is not
+    // invalidated yet.
+    session.set("data.nextURL", location.href.replace(location.origin, ""));
+    session.invalidate();
+  }
   if (macroCondition(isTesting())) {
     // don't redirect in tests
   } else {
-    location.replace(
-      getAbsoluteUrl(getConfig(getOwner(session)).afterLogoutUri || "")
-    );
+    // defer the redirect, so the first unauthenticated request can trigger
+    // the redirect to the login page before another request will intercept
+    // the process and a race condition would start.
+    next(() => {
+      location.replace(
+        getAbsoluteUrl(getConfig(getOwner(session)).afterLogoutUri || "")
+      );
+    });
   }
 }


### PR DESCRIPTION
We have seen redirect loops when the refresh token expired and the authenticator tried to redirect to the initial route after a fresh token was acquired. 

The `handleUnauthorized` method is called on every unauthenticated request (`401` response). It will then trigger `invalidate` session and redirect to `/`.  Since a lot of requests can get triggered on `/` we have to defer the redirect for a while, to give the chance to redirect to the authentication route first, before other *failed* request would try to do the same. (*race condition*)