### PR TITLE
fix: prevent race condition in unauthorized handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,10 @@ export default class LoginRoute extends OIDCAuthenticationRoute {}
 
 Authenticated routes need to call `session.requireAuthentication` in their
 respective `beforeModel`, to ensure that unauthenticated transitions are
-prevented and redirected to the authentication route.
+prevented and redirected to the authentication route. It's recommended to 
+await the `beforeModel` hook, to make sure authentication is handled before
+other API calls are triggered (which might lead to `401` responses, potentially
+causing redirect loops).
 
 ```js
 // app/routes/protected.js
@@ -53,8 +56,8 @@ import { inject as service } from "@ember/service";
 export default class ProtectedRoute extends Route {
   @service session;
 
-  beforeModel(transition) {
-    this.session.requireAuthentication(transition, "login");
+  async beforeModel(transition) {
+    await this.session.requireAuthentication(transition, "login");
   }
 }
 ```
@@ -238,6 +241,9 @@ Timeout in milliseconds between each retry if a token refresh should fail. Defau
 
 **enablePkce** `<Boolean>` (optional)
 Enables PKCE mechanism to provide additional protection during code to token exchanges. Default is `false`.
+
+**unauthorizedRequestRedirectTimeout** `<Number>` (optional)
+Debounce timeout for redirection after (multiple) `401` responses are received to prevent redirect loops (at the cost of a small delay). Set to `0` to disable debouncing. Default is `1000`.
 
 ## Contributing
 

--- a/addon/config.js
+++ b/addon/config.js
@@ -22,6 +22,7 @@ export function getConfig(owner) {
     ...(owner.resolveRegistration("config:environment")[
       "ember-simple-auth-oidc"
     ] ?? {}),
+    unauthorizedRequestRedirectTimeout: 1000,
   };
 }
 

--- a/addon/unauthorized.js
+++ b/addon/unauthorized.js
@@ -24,6 +24,11 @@ export default function handleUnauthorized(session) {
     // Debounce the redirect, so we can collect all unauthorized requests and trigger a final
     // redirect. We don't want to interrupt calls to the authorization endpoint nor create race
     // conditions when multiple requests land in this unauthorized handler.
-    debounce(this, replaceUri, session, 1000);
+    debounce(
+      this,
+      replaceUri,
+      session,
+      getConfig(getOwner(session)).unauthorizedRequestRedirectTimeout
+    );
   }
 }


### PR DESCRIPTION
When multiple requests failed with a `401` status, they would trigger reconnects to the auth endpoint. Sadly this created a race condition. While the first connection to the auth endpoint was made, another old request already failed with a `401` interrupting the previous auth request and the page would load anew beginning the cycle again. This is caused, by the [browser not canceling the commissioned fetch](https://stackoverflow.com/questions/8566222/javascript-window-redirect-doesnt-work-in-chrome-canceled-status/67992162#67992162) requests after the `location.replace(...)` call. The previous `next(...)` call was certainly not enough time for all the eventual requests to finish.
![image](https://user-images.githubusercontent.com/10029904/232852094-8edf4e90-f9df-469b-9947-c525a537523b.png)

Now we *collect* all the failing requests in a 1 second timespan and redirect after that. This prevents the race condition.