### PR TITLE
chore(dummy-app): create users from factory

### DIFF
--- a/tests/dummy/mirage/factories/user.js
+++ b/tests/dummy/mirage/factories/user.js
@@ -1,0 +1,6 @@
+import { Factory } from "miragejs";
+
+export default Factory.extend({
+  username: "test",
+  email: "test@example.com",
+});


### PR DESCRIPTION
Currently the test app is broken, cause it doesn't know how to create the mocked `user` models.