### PR TITLE
Pass config.store to discoverEmberDataModels

### DIFF
--- a/tests/dummy/mirage/config.js
+++ b/tests/dummy/mirage/config.js
@@ -4,7 +4,7 @@ import { createServer, Response } from "miragejs";
 export default function makeServer(config) {
   return createServer({
     ...config,
-    models: { ...discoverEmberDataModels(), ...config.models },
+    models: { ...discoverEmberDataModels(config.store), ...config.models },
     routes() {
       this.urlPrefix = "http://localhost:4200";
       this.namespace = "";


### PR DESCRIPTION
I was getting an error about a missing `User` model because we weren't passing a necessary argument in `mirage/config.js`.