### PR TITLE
Support for audience parameter; fix post_logout_redirect_uri

### DIFF
--- a/addon/authenticators/oidc.js
+++ b/addon/authenticators/oidc.js
@@ -101,7 +101,6 @@ export default class OidcAuthenticator extends BaseAuthenticator {
       params.push(
         `post_logout_redirect_uri=${getAbsoluteUrl(
           this.config.afterLogoutUri,
-          this.config.host,
         )}`,
       );
     }

--- a/addon/routes/oidc-authentication.js
+++ b/addon/routes/oidc-authentication.js
@@ -168,6 +168,10 @@ export default class OIDCAuthenticationRoute extends Route {
       search.push("code_challenge_method=S256");
     }
 
+    if (this.config.audience) {
+      search.push(`audience=${this.config.audience}`);
+    }
+
     search = search.filter(Boolean).join("&");
 
     this._redirectToUrl(

--- a/addon/services/config.js
+++ b/addon/services/config.js
@@ -22,6 +22,7 @@ const defaultConfig = {
   retryTimeout: 3000,
   enablePkce: false,
   unauthorizedRequestRedirectTimeout: 1000,
+  audience: null,
 };
 
 const aliases = {


### PR DESCRIPTION
This PR addresses 2 items

1. Fix the `post_logout_redirect_uri`
The uri is computing by concatenating afterLogoutUri to the issuer URI, which is incorrect.  It should concatenate the URI to the current window location, as we want to redirect the client back to our app after the login.

2. Add support for the `audience` authorize parameter.
This is a quite popular parameter for the `/authorize` call, required by Auth0.